### PR TITLE
fix ipv4 ipv6 options

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3727,6 +3727,11 @@ void initialize_screen(int *argc, char **argv, XImage *fb) {
 		defer_update = screen->deferUpdateTime;
 	}
 
+	// from the man page:
+	// "IPv6 address is listened on for incoming connections.
+	//  The same port number as IPv4 is used."
+	screen->ipv6port = (!ipv6_listen || noipv6) ? (-1) : screen->port;
+
 	if (noipv4 || getenv("IPV4_FAILS")) {
 		rfbBool ap = screen->autoPort;
 		int port = screen->port;
@@ -3753,7 +3758,7 @@ void initialize_screen(int *argc, char **argv, XImage *fb) {
 			https_port(0);
 		}
 	} else {
-		if (ipv6_listen) {
+		if (ipv6_listen && !noipv6 && screen->listen6Sock < 0) {
 			int fd = -1;
 			if (screen->port <= 0) {
 				if (got_rfbport) {

--- a/src/user.c
+++ b/src/user.c
@@ -3049,7 +3049,7 @@ int wait_for_client(int *argc, char** argv, int http) {
 	initialize_screen(argc, argv, fb_image);
 
 	if (! inetd && ! use_openssl) {
-		if (! screen->port || screen->listenSock < 0) {
+		if (! screen->port || (screen->listenSock < 0 && screen->listen6Sock < 0)) {
 			if (got_rfbport && got_rfbport_val == 0) {
 				;
 			} else if (ipv6_listen && ipv6_listen_fd >= 0) {

--- a/src/x11vnc.c
+++ b/src/x11vnc.c
@@ -4962,8 +4962,10 @@ int main(int argc, char* argv[]) {
 	    argv_vnc[argc_vnc++] = strdup("-listen");
 	    argv_vnc[argc_vnc++] = strdup(listen_str);
 #ifdef LIBVNCSERVER_IPv6
-	    argv_vnc[argc_vnc++] = strdup("-listenv6");
-	    argv_vnc[argc_vnc++] = strdup(listen_str);
+		if (! noipv6 && ipv6_listen) {
+			argv_vnc[argc_vnc++] = strdup("-listenv6");
+			argv_vnc[argc_vnc++] = strdup(listen_str);
+		}
 #endif
 	    allow_list = strdup("127.0.0.1");
 	}
@@ -5909,7 +5911,7 @@ int main(int argc, char* argv[]) {
 		}
 	}
 	if (! inetd && ! use_openssl) {
-		if (! screen->port || screen->listenSock < 0) {
+		if (! screen->port || (screen->listenSock < 0 && screen->listen6Sock < 0)) {
 			if (got_rfbport && got_rfbport_val == 0) {
 				;
 			} else if (ipv6_listen && ipv6_listen_fd >= 0) {

--- a/src/x11vnc.c
+++ b/src/x11vnc.c
@@ -5913,14 +5913,19 @@ int main(int argc, char* argv[]) {
 	if (! inetd && ! use_openssl) {
 		if (! screen->port || (screen->listenSock < 0 && screen->listen6Sock < 0)) {
 			if (got_rfbport && got_rfbport_val == 0) {
-				;
+				rfbLog("Info: listening suppressed; see '-connect' and\n");
+				rfbLog("  and '-connect_or_exit' for details.\n");
 			} else if (ipv6_listen && ipv6_listen_fd >= 0) {
 				rfbLog("Info: listening only on IPv6 interface.\n");
 			} else {
 				rfbLogEnable(1);
-				rfbLog("Error: could not obtain listening port.\n");
+				rfbLog("Error: could not obtain any listening port.\n");
 				if (!got_rfbport && !got_ipv6_listen) {
+#if X11VNC_IPV6
 					rfbLog("If this system is IPv6-only, use the -6 option.\n");
+#else
+					rfbLog("Sorry, this build does not support IPv6.\n");
+#endif
 				}
 				clean_up_exit(1);
 			}


### PR DESCRIPTION
The command-line options for ipv4 and ipv6 had a few bugs, mostly involving an inability to actually suppress IPv6 listening. With these changes, it's now possible to "-noipv4" to run with just IPv6, "-noipv6" or "-no6" to suppress IPv6 listening, or even "-noipv4 -noipv6 -rfbport 0 -connect_or_exit example.org" ( reverse-connect to remote client with no local listeners ).

Beware, however, as this change fixes a quirk where if using IPv4 and v6, it wasn't possible to specify a separate listening port for each protocol, but the manual says the v6 port is based on the v4 port. It might be best to eventually have an "-rfbportv6" option -- and I've seen talk floating around that there is such an option, but it isn't in the codebase I forked. In any case, the code now agrees with the manual, but may induce unwanted changes in your workflows.